### PR TITLE
fix: Used called callbacks to calculate sleep time

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
 # Instalacja wszystkich narzędzi w jednej warstwie
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y python3-pip curl git qemu-system-arm qemu-utils \
-    && pip3 install cpplint==1.6.1 --break-system-packages \
+    && pip3 install cpplint==1.6.1 pylint --break-system-packages \
     # Pobieranie Bazeliska
     && curl -L https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 -o /usr/local/bin/bazel \
     && chmod +x /usr/local/bin/bazel \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
     "name": "C++ Bazel Podman (Native)",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "image": "ghcr.io/simba-avionic/simba_avionics_dockers/devcontainer",
 	"customizations": {
         "vscode": {
             "extensions": [
@@ -25,7 +23,11 @@
                 "bsv.bazel.executable": "/usr/local/bin/bazel",
                 "bsv.buildozer.executable": "/usr/local/bin/buildozer",
                 "doxdocgen.generic.authorName": "${localEnv:DEV_AUTHOR_NAME}",
-                "doxdocgen.generic.authorEmail": "${localEnv:DEV_AUTHOR_EMAIL}"
+                "doxdocgen.generic.authorEmail": "${localEnv:DEV_AUTHOR_EMAIL}",
+                "editor.formatOnSave": true,
+                "[bazel]": {
+                    "editor.defaultFormatter": "bazelbuild.vscode-bazel"
+                }
             }
         }
     },

--- a/.github/workflows/lint_build_test.yml
+++ b/.github/workflows/lint_build_test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/lint_build_test.yml
+++ b/.github/workflows/lint_build_test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run cpplint
         run: |
-          /bin/bash ./tools/cpplint/cpplint.sh
+          ./tools/cpplint/cpplint.sh
 
   build-and-test:
     name: SRP Build & Test SRP

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@ deps()
 load("//bazel/libs:third_party_repositories.bzl", "include_srp_platform", "include_srp_mavlink",
      "include_gtest_mock", "include_simdjson", "include_json", "include_simulation_data")
 
-include_srp_platform("0.0.9", "SRP-Platform/srp_platform")
+include_srp_platform("release-2503")
 
 load("@srp_platform//:download.bzl", "download")
 download()

--- a/bazel/libs/third_party_repositories.bzl
+++ b/bazel/libs/third_party_repositories.bzl
@@ -20,11 +20,11 @@ def include_simdjson(ver, sha256):
         sha256 = sha256,
     )
 
-def include_srp_platform(ver, source):
+def include_srp_platform(ver):
         http_archive(
         name = "srp_platform",
         strip_prefix = "srp_platform",
-        urls = ["https://artifactory.srp-platform.com/artifactory/srp-oss-platform/release-2503/srp_platform.zip"],
+        urls = ["https://artifactory.srp-platform.com/artifactory/srp-oss-platform/"+ ver + "/srp_platform.zip"],
         type = "zip",
     )
     

--- a/core/onTimerCallback/onTimer.cpp
+++ b/core/onTimerCallback/onTimer.cpp
@@ -36,6 +36,13 @@ void TimerController::Loop(const std::stop_token& token) {
                 if (elapsed > timer.Interval_ms) {
                     timer.last_call += std::chrono::milliseconds(timer.Interval_ms);
                     callbacks_to_run.push_back(timer.callback);
+                    const auto next_elapsed = std::chrono::duration_cast<
+                        std::chrono::milliseconds>(now - timer.last_call).count();
+                    const int64_t time_to_next =
+                        static_cast<int64_t>(timer.Interval_ms) - next_elapsed;
+                    const uint32_t sleep_cap = static_cast<uint32_t>(
+                        std::max<int64_t>(0, time_to_next));
+                    can_sleep_for_ms = std::min(can_sleep_for_ms, sleep_cap);
                 } else {
                     uint32_t time_to_next_callback = timer.Interval_ms - elapsed;
                     can_sleep_for_ms = std::min(can_sleep_for_ms, time_to_next_callback);


### PR DESCRIPTION
Poprzedni desingn nie uwzględniał możliwości że najbliższy callback do wywołania to ten właśnie wywołany, więc w przypadku 1 callbacka z czasem krótszym niż 1s wywoływany on był i tak co 1s